### PR TITLE
Added Subject (ClaimsPrincipal) to refreshtoken store

### DIFF
--- a/Source/Core.MongoDb.Tests/TestData.cs
+++ b/Source/Core.MongoDb.Tests/TestData.cs
@@ -197,7 +197,8 @@ namespace Core.MongoDb.Tests
                 AccessToken = Token(subject),
                 CreationTime = new DateTimeOffset(2000, 1, 1, 1, 1, 1, 0, TimeSpan.Zero),
                 LifeTime = 100,
-                Version = 10
+                Version = 10,
+                Subject = new ClaimsPrincipal(new ClaimsIdentity(Claims(subject)))
             };
         }
 


### PR DESCRIPTION
Hi @jageall ,

Is there a missing Serializer for ClaimsPrincipal when it comes to the subject property of RefreshToken?

Some users experienced errors with the mongodb backing stores after upgrading idsrv to 2.6.0 , where the Subject property of RefreshToken is in use.


 https://github.com/IdentityServer/IdentityServer3/issues/3470